### PR TITLE
bump CI pinned Nautobot from 2.4.27 to 3.0.11

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       nautobot:
-        image: ghcr.io/nautobot/nautobot:2.4.27
+        image: ghcr.io/nautobot/nautobot:3.0.11
         env:
           NAUTOBOT_DB_HOST: postgres
           NAUTOBOT_DB_NAME: nautobot

--- a/docs/compat.md
+++ b/docs/compat.md
@@ -6,7 +6,7 @@ series is inferred from the absence of breaking api changes in that range.
 
 | nautobot.rs | nautobot | notes                                |
 |-------------|----------|--------------------------------------|
-| 0.3.x       | 2.4.x    | CI pinned to 2.4.27                  |
+| 0.3.x       | 2.4.x – 3.0.x | CI pinned to 3.0.11                  |
 
 older client releases have not been retroactively tested.
 


### PR DESCRIPTION
Bump the integration CI Nautobot image tag from 2.4.27 to 3.0.11 and update compat.md.

**Note:** This is a major version bump (2.x → 3.x). The oasdiff breaking-change check will flag API changes, and smoke/golden tests will show whether the generated client still works. Marking as draft until CI results are reviewed.

Closes #1

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._