### PR TITLE
ci: switch from Swatinem/rust-cache to kache, cache integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-clippy
       - run: cargo clippy -p nautobot -p nautobot-cli --all-targets -- -D warnings
 
   test:
@@ -44,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-test
       - run: cargo test -p nautobot -p nautobot-cli
 
   doc:
@@ -55,7 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-doc
       - run: cargo doc --workspace --no-deps
 
   deny:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-smoke-and-golden
+
       - name: Wait for Nautobot readiness
         env:
           NAUTOBOT_TOKEN: ci-superuser-api-token


### PR DESCRIPTION
Same pattern as netbox.rs PR #28 + infrahub.rs PR #38.

- ci.yml: replace Swatinem with kache (per-rustc content-addressed) in clippy/test/doc, with per-job cache-key-prefix.
- integration.yml: add a cache step (smoke-and-golden previously rebuilt from zero every run).

Reference benchmark from netbox.rs: warm test job 2m 59s → 34s, 100% kache hit rate.