### PR TITLE
release v0.4.1: fix docs.rs OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [0.4.1] - 2026-05-31
+
+### build
+- gate per-tag API modules (`dcim_api`, `ipam_api`, `vpn_api`, etc.) behind `#[cfg(not(docsrs))]` so docs.rs skips compiling them. The high-level `nautobot` client only uses `apis::configuration` (plus re-exports `apis`), so users on crates.io see no change; only `docs.rs/nautobot-openapi/` loses the per-tag pages. Mirrors the netbox.rs 0.5.3 fix.
+- added `crates/nautobot-openapi/build.rs` that translates docs.rs's `DOCS_RS=1` env into `cfg(docsrs)`.
+- `scripts/generate.sh` post-processing keeps the gates on subsequent regenerations.
+
 ### openapi
 - regenerate bindings from Nautobot 3.1.2 (removes `image_height`/`image_width` from image-attachment request bodies, `current_head` from git-repository request bodies)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["cyber witchery labs"]
 edition = "2024"
 rust-version = "1.91"
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # nautobot bindings
-nautobot-openapi = { version = "0.4.0", path = "crates/nautobot-openapi" }
+nautobot-openapi = { version = "0.4.1", path = "crates/nautobot-openapi" }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/nautobot-cli/Cargo.toml
+++ b/crates/nautobot-cli/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-nautobot = { version = "0.4.0", path = "../nautobot" }
+nautobot = { version = "0.4.1", path = "../nautobot" }
 clap = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nautobot-openapi/Cargo.toml
+++ b/crates/nautobot-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nautobot-openapi"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/nautobot-openapi/build.rs
+++ b/crates/nautobot-openapi/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(docsrs)");
+    if std::env::var("DOCS_RS").is_ok() {
+        println!("cargo:rustc-cfg=docsrs");
+    }
+}

--- a/crates/nautobot-openapi/src/apis/mod.rs
+++ b/crates/nautobot-openapi/src/apis/mod.rs
@@ -92,24 +92,43 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+#[cfg(not(docsrs))]
 pub mod circuits_api;
+#[cfg(not(docsrs))]
 pub mod cloud_api;
+#[cfg(not(docsrs))]
 pub mod core_api;
+#[cfg(not(docsrs))]
 pub mod data_validation_api;
+#[cfg(not(docsrs))]
 pub mod dcim_api;
+#[cfg(not(docsrs))]
 pub mod extras_api;
+#[cfg(not(docsrs))]
 pub mod graphql_api;
+#[cfg(not(docsrs))]
 pub mod ipam_api;
+#[cfg(not(docsrs))]
 pub mod load_balancers_api;
+#[cfg(not(docsrs))]
 pub mod status_api;
+#[cfg(not(docsrs))]
 pub mod swagger_api;
+#[cfg(not(docsrs))]
 pub mod swagger_json_api;
+#[cfg(not(docsrs))]
 pub mod swagger_yaml_api;
+#[cfg(not(docsrs))]
 pub mod tenancy_api;
+#[cfg(not(docsrs))]
 pub mod ui_api;
+#[cfg(not(docsrs))]
 pub mod users_api;
+#[cfg(not(docsrs))]
 pub mod virtualization_api;
+#[cfg(not(docsrs))]
 pub mod vpn_api;
+#[cfg(not(docsrs))]
 pub mod wireless_api;
 
 pub mod configuration;

--- a/crates/nautobot-openapi/src/lib.rs
+++ b/crates/nautobot-openapi/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(clippy::all)]
+#![allow(unexpected_cfgs)]
 #[macro_use]
 extern crate serde_derive;
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -177,6 +177,7 @@ attrs = "\n".join([
     "#![allow(non_camel_case_types)]",
     "#![allow(non_upper_case_globals)]",
     "#![allow(clippy::all)]",
+    "#![allow(unexpected_cfgs)]",
     "",
 ])
 
@@ -184,6 +185,23 @@ if attrs not in content:
     content = attrs + content
     with open(path, "w", encoding="utf-8") as handle:
         handle.write(content)
+PY
+
+echo "Gating per-tag API modules behind cfg(not(docsrs))..."
+python3 - <<'PY' "${HOST_OUTPUT_DIR}/src/apis/mod.rs"
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    content = handle.read()
+
+pattern = re.compile(r"^pub mod ([a-z_]+_api);$", re.MULTILINE)
+replacement = r"#[cfg(not(docsrs))]\npub mod \1;"
+content = pattern.sub(replacement, content)
+
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(content)
 PY
 
 echo "Normalizing generated Cargo.toml dependencies..."


### PR DESCRIPTION
Same fix as netbox.rs PR #30 (released as v0.5.3). docs.rs builds for `nautobot` have been failing with `container ran out of memory` since v0.4.0 — exact same root cause: rustc OOMs type-checking `nautobot-openapi`'s ~250k+ lines of derive-heavy generated code under docs.rs's 6 GiB container limit.

Verified independently for netbox.rs: cgroup-limited Linux container test went from OOM at 6 GiB to 3.98 GiB peak after the gate; docs.rs reported 4.2 GB for the actual build of netbox v0.5.3.

## Changes

- `crates/nautobot-openapi/src/apis/mod.rs`: `#[cfg(not(docsrs))]` on each of the 19 `pub mod *_api;` declarations (gates them on docs.rs only).
- `crates/nautobot-openapi/build.rs` (new, 6 lines): translates docs.rs's `DOCS_RS=1` env into `cfg(docsrs)`.
- `crates/nautobot-openapi/src/lib.rs`: `#![allow(unexpected_cfgs)]`.
- `scripts/generate.sh`: python post-process to re-apply the gates after openapi-generator runs.

## What users see

| | crates.io | docs.rs (nautobot-openapi page) | docs.rs (nautobot page) |
|---|---|---|---|
| `models::*` | ✓ | ✓ documented | re-exported |
| `apis::configuration` | ✓ | ✓ documented | used internally |
| `apis::dcim_api` etc. (19 modules) | ✓ | **gated, not documented** | not called by nautobot |
| `nautobot::Client`, idiomatic API | ✓ | (different crate) | ✓ documented |

No source changes in `crates/nautobot` because nautobot only uses `nautobot_openapi::apis::configuration` — never calls the per-tag api functions, only re-exports them.