### PR TITLE
fix(deps): enable reqwest 'query' feature (0.13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["api-bindings", "network-programming"]
 
 [workspace.dependencies]
 # HTTP client
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "query"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/nautobot-openapi/Cargo.toml
+++ b/crates/nautobot-openapi/Cargo.toml
@@ -21,5 +21,5 @@ url = "^2.2"
 uuid = { version = "^1.0", features = ["serde"] }
 [dependencies.reqwest]
 version = "^0.13"
-features = ["json", "multipart", "rustls"]
+features = ["json", "multipart", "rustls", "query"]
 default-features = false


### PR DESCRIPTION
reqwest 0.13 gates `RequestBuilder::query` behind the `query` feature; the generated client uses it. Adds the feature to the root and nautobot-openapi manifests to fix the build that #22 broke on main.